### PR TITLE
fix aarch64

### DIFF
--- a/packet_plugin/rjv3/rjv3_hashes/byte_order.h
+++ b/packet_plugin/rjv3/rjv3_hashes/byte_order.h
@@ -40,7 +40,7 @@ extern "C" {
 		__BYTE_ORDER == __LITTLE_ENDIAN) || \
 	defined(CPU_IA32) || defined(CPU_X64) || \
 	defined(__ia64) || defined(__ia64__) || defined(__alpha__) || defined(_M_ALPHA) || \
-	defined(vax) || defined(MIPSEL) ||defined(_MIPSEL) ||defined(__MIPSEL)|| defined(_ARM_) || defined(__arm__)
+	defined(vax) || defined(MIPSEL) ||defined(_MIPSEL) ||defined(__MIPSEL)|| defined(_ARM_) || defined(__arm__) || defined(__aarch64__)
 # define CPU_LITTLE_ENDIAN
 # define IS_BIG_ENDIAN 0
 # define IS_LITTLE_ENDIAN 1


### PR DESCRIPTION
为N1编译时发现少了aarch64字段